### PR TITLE
Convert date to W3CDTF-Schema

### DIFF
--- a/action.php
+++ b/action.php
@@ -104,8 +104,8 @@ class action_plugin_metaheaders extends DokuWiki_Action_Plugin {
 
         $replace = array('@AUTHOR@'       => $INFO['meta']['creator'],
                          '@ID@'           => $INFO['id'],
-                         '@CREATED@'      => $INFO['meta']['date']['created'],
-                         '@LASTMOD@'      => $INFO['lastmod'],
+                         '@CREATED@'      => date('Y-m-d\TH:i:sO',$INFO['meta']['date']['created']),
+                         '@LASTMOD@'      => date('Y-m-d\TH:i:sO',$INFO['lastmod']),
                          '@ABSTRACT@'     => preg_replace("/\s+/", ' ', $INFO['meta']['description']['abstract']),
                          '@TITLE@'        => $INFO['meta']['title'],
                          '@RELATION@'     => @implode(', ', @array_keys($INFO['meta']['relation']['references'])),


### PR DESCRIPTION
At least with the current development version of dokuwiki (ff71173) the
@LASTMOD@ and @CREATED@ fields did not contain data values. Therefore I
added a conversion to a W3CDTF schema, as it is already used in dw's
inc/template.php

Signed-off-by: Daniel Kriesten krid@tu-chemnitz.eu
