### PR TITLE
Avoid an empty list of data

### DIFF
--- a/action.php
+++ b/action.php
@@ -82,6 +82,7 @@ class action_plugin_metaheaders extends DokuWiki_Action_Plugin {
 	                    }
 	                    if ($unset) {
 	                        unset($head[$outerType][$i]);
+				if ( empty($head[$outerType]) ) unset( $head[$outerType] );
 	                    }
 	                }
 	            }


### PR DESCRIPTION
If the list is empty, an empty `<meta />` tag is generated