### PR TITLE
Correct declaration of function register

### DIFF
--- a/action.php
+++ b/action.php
@@ -34,7 +34,7 @@ require_once(DOKU_PLUGIN.'action.php');
  */
 class action_plugin_metaheaders extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'metaheaders');
     }
 


### PR DESCRIPTION
Corrects php error "PHP message: PHP Warning:  Declaration of action_plugin_metaheaders::register(Doku_Event_Handler &$controller) should be compatible with DokuWiki_Action_Plugin::register(Doku_Event_Handler $controller)"