### PR TITLE
fix undefined array key "cond" error

### DIFF
--- a/action.php
+++ b/action.php
@@ -116,7 +116,7 @@ class action_plugin_metaheaders extends DokuWiki_Action_Plugin {
                 foreach ($headers[$type] as $header) {
                     $skip = false;
 
-                    if ($header['cond']) {
+                    if (isset($header['cond']) && $header['cond']) {
                         if (preg_match('/'.$header['cond'].'/', $ID)) {
                             unset($header['cond']);
                         } else{


### PR DESCRIPTION
fix the error:
AH01071: Got error 'PHP message: PHP Warning:  Undefined array key "cond" in /var/www/dokuwiki/lib/plugins/metaheaders/action.php on line 119'